### PR TITLE
Note that capybara/rspec's matchers already use the negated assertion in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ execution expired (Timeout::Error)
 
 If you look at the lines below the gem's trace, you'll see that the slow finder is in `signed_in_user.rb` on line 31 in the `signed_in?` method. Just follow those traces and clean up your code!
 
+## RSpec
+
+If you're using RSpec and the matchers provided by Capybara like:
+
+```ruby
+expect(page).to_not have_content("abc")
+```
+
+then Capybara is already telling RSpec to use the negated method (`has_no_content?`) and thus Capybara is not waiting for the timeout before continuing.
+
 ## Common Fixes
 
 This section will hopefully grow as people contribute common situations and fixes.


### PR DESCRIPTION
I love the idea of this gem and was eager to see if I could speed up my test suite by eliminating waiting for the timeouts, but I was disappointed when none of my tests failed due to waiting for the timeout.

It turns out the matchers Capybara defines already use the negated version of each assertion (for example: https://github.com/jnicklas/capybara/blob/4161bbc560631e61e611d59bf797eeb59a6b1021/lib/capybara/rspec/matchers.rb#L71), so you're already guarded against accidentally waiting the full timeout.

I'm not thrilled with the copy I added, but figured its a start to alerting others that Capybara may already be handling this for you when used with RSpec.
