### PR TITLE
Raise current exception if it’s not a timeout

### DIFF
--- a/lib/capybara/slow_finder_errors.rb
+++ b/lib/capybara/slow_finder_errors.rb
@@ -11,6 +11,7 @@ module Capybara
         if Time.now-start_time > seconds
           raise SlowFinderError
         end
+        raise
       end
       alias_method :synchronize_without_timeout_error, :synchronize
       alias_method :synchronize, :synchronize_with_timeout_error


### PR DESCRIPTION
This PR implements the problem described on ngauthier/capybara-slow_finder_errors#2
