### PR TITLE
Add a descriptive message to the raised error

### DIFF
--- a/lib/capybara/slow_finder_errors.rb
+++ b/lib/capybara/slow_finder_errors.rb
@@ -9,7 +9,7 @@ module Capybara
         synchronize_without_timeout_error(seconds, options, &block)
       rescue Capybara::ElementNotFound => e
         if Time.now-start_time > seconds
-          raise SlowFinderError
+          raise SlowFinderError, "Timeout reached while running a *waiting* Capybara finder...perhaps you wanted to return immediately? Use a non-waiting Capybara finder. More info: http://blog.codeship.com/faster-rails-tests?utm_source=gem_exception"
         end
         raise
       end


### PR DESCRIPTION
I want to include this gem into our project, but I'm afraid that the error will cause questions for team members that are unfamiliar with the problem that is being caught. Make the error message more descriptive, and point to the blog post. This is more like how the vcr gem raises errors.
