### PR TITLE
Be more lenient about args to be more compatible with capybara versions

### DIFF
--- a/lib/capybara/slow_finder_errors.rb
+++ b/lib/capybara/slow_finder_errors.rb
@@ -4,10 +4,11 @@ module Capybara
 
   module Node
     class Base
-      def synchronize_with_timeout_error(seconds=Capybara.default_wait_time, options = {}, &block)
+      def synchronize_with_timeout_error(*args, &block)
         start_time = Time.now
-        synchronize_without_timeout_error(seconds, options, &block)
+        synchronize_without_timeout_error(*args, &block)
       rescue Capybara::ElementNotFound => e
+        seconds = args.first || Capybara.default_wait_time
         if Time.now-start_time > seconds
           raise SlowFinderError, "Timeout reached while running a *waiting* Capybara finder...perhaps you wanted to return immediately? Use a non-waiting Capybara finder. More info: http://blog.codeship.com/faster-rails-tests?utm_source=gem_exception"
         end


### PR DESCRIPTION
I _think_ this fixes #4, it makes it work for my application where I'm using capybara 2.1.0, at least.
