### PR TITLE
Handle zero wait time passed to a waiting finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Returns true if they are signed in, but it waits a full timeout before returning
 ```ruby
 def signed_in?
   page.has_content?("Dashboard")
-  page.all('a', :text => 'Home').any?
+  page.has_css?('a', :text => 'Home', :wait => false)
 end
 ```
 

--- a/lib/capybara/slow_finder_errors.rb
+++ b/lib/capybara/slow_finder_errors.rb
@@ -9,7 +9,7 @@ module Capybara
         synchronize_without_timeout_error(*args, &block)
       rescue Capybara::ElementNotFound => e
         seconds = args.first || Capybara.default_wait_time
-        if Time.now-start_time > seconds
+        if seconds > 0 && Time.now-start_time > seconds
           raise SlowFinderError, "Timeout reached while running a *waiting* Capybara finder...perhaps you wanted to return immediately? Use a non-waiting Capybara finder. More info: http://blog.codeship.com/faster-rails-tests?utm_source=gem_exception"
         end
         raise


### PR DESCRIPTION
Capybara 2.1+ supports a :wait option on all finders which can be used
to disable the waiting behaviour:

  has_text?("Home", wait: false)
  has_css?("ol li.options", wait: 0)

Fixing code which hits the timeout in this wait will often require less
thought and fewer changes than using a non waiting finder like
`all(...).any?` or `first`.

I also think it reads better and is more explicit.
