### PR TITLE
Add support for Capybara versions greater than 2.5

### DIFF
--- a/capybara-slow_finder_errors.gemspec
+++ b/capybara-slow_finder_errors.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "capybara-slow_finder_errors"
-  spec.version       = "0.1.4"
+  spec.version       = "0.1.5"
   spec.authors       = ["Nick Gauthier"]
   spec.email         = ["ngauthier@gmail.com"]
   spec.summary       = %q{Raises an error when you use a Capybara finder improperly}
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_dependency "capybara", "~> 2.5"
+  spec.add_dependency "capybara", ">= 2.5"
 end


### PR DESCRIPTION
* Previously the Capybara version was locked at 2.5; this commit changes
the gem versioning to allow for Capybara versions greater than 2.5.

* This change allows users to continue using 2.5 if they're still on it
and also opens up the gem for users who want to utilize Capybara 3.*.

* Because this is backwards compatible I increased the gem version only
by a patch level from "0.1.4" to "0.1.5".