### PR TITLE
Ruby 3.x compatibility

### DIFF
--- a/capybara-slow_finder_errors.gemspec
+++ b/capybara-slow_finder_errors.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_dependency "capybara", "~> 3.0"
 end

--- a/lib/capybara/slow_finder_errors.rb
+++ b/lib/capybara/slow_finder_errors.rb
@@ -4,9 +4,9 @@ module Capybara
 
   module Node
     class Base
-      def synchronize_with_timeout_error(*args, &block)
+      def synchronize_with_timeout_error(*args, **kwargs, &block)
         start_time = Time.now
-        synchronize_without_timeout_error(*args, &block)
+        synchronize_without_timeout_error(*args, **kwargs, &block)
       rescue Capybara::ElementNotFound => e
         seconds = args.first || Capybara.default_max_wait_time
         raise e unless seconds > 0 && Time.now-start_time > seconds


### PR DESCRIPTION
`**kwargs` must be forwarded explicitly now. (We can't use `...` syntax because we actually check `args.first` in the `rescue` block.)